### PR TITLE
Refactor adding data-spy attribute to nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ in the plugin.
 Change Log
 --------------------------
 
+### [1.1.2][2018-02-20]
+- Corrrect adding data-spy attribute to nav ([#10](https://github.com/salcode/bootstrap-genesis-fixed-nav/issues/10))
+
 ### [1.1.1][2015-08-26]
 - Add composer.json file
 - Add body class .bootstrap-genesis-fixed-nav to target the CSS so it is only

--- a/bootstrap-genesis-fixed-nav.php
+++ b/bootstrap-genesis-fixed-nav.php
@@ -3,7 +3,7 @@
  * Plugin Name: Bootstrap Genesis Fixed Nav
  * Plugin URI:
  * Description: Modifies the Primary Navigation Menu so it is fixed to the top of the page
- * Version: 1.1.0
+ * Version: 1.1.2
  * Author: Sal Ferrarello
  * Author URI: http://salferrarello.com/
  * Text Domain: bootstrap-genesis-fixed-nav
@@ -27,7 +27,7 @@ class Bootstrap_Genesis_Fixed_Nav {
 	public function __construct() {
 		add_filter( 'bsg-classes-to-add', array( $this, 'modify_nav_class' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'load_css' ) );
-		add_filter( 'genesis_markup_nav-primary_output',  array( $this, 'add_boot_strap_affix_markup' ) );
+		add_filter( 'genesis_do_nav',  array( $this, 'add_boot_strap_affix_markup' ) );
 		add_filter( 'option_hash_link_scroll_offset', array( $this, 'option_hash_link_scroll_offset' ) );
 		add_filter( 'body_class', array( $this, 'add_body_class' ) );
 	}
@@ -110,7 +110,7 @@ class Bootstrap_Genesis_Fixed_Nav {
 	 *                the affix behavior
 	 */
 	public function add_boot_strap_affix_markup( $markup ) {
-		$markup = rtrim( $markup, ">" ) . 'data-spy="affix" data-offset-top="32">';
+		$markup = '<nav data-spy="affix" data-offset-top="32" ' . ltrim( $markup, '<nav ' );
 		return $markup;
 	}
 }


### PR DESCRIPTION
Bootstrap Genesis previously negelected to remove the .no-js class on
the html element.

Therefore, the fallback CSS for .no-js was being applied, which
prevented this issue surfacing.  The data-spy attribute was not being
applied therefore the JavaScript version of the fixed nav was not
occurring.

This fixes the problem by correctly adding the data-spy attribute by

- correcting the filter hook
- correcting the string modification

See #10